### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,12 +10,15 @@ exports.get = function() {
     if (_rootDir === undefined) {
         var fs = require('fs');
         var path = require('path');
-
+        var nm = path.sep + 'node_modules' + path.sep;
         var cwd = process.cwd();
-        if (fs.existsSync(path.join(cwd, 'package.json'))) {
+        var pos = cwd.indexOf(nm);
+        if (pos !== -1) {
+            __rootDir =  cwd.substring(0, pos);
+        } else if (fs.existsSync(path.join(cwd, 'package.json'))) {
             _rootDir = cwd;
         } else {
-            var pos = __dirname.indexOf('/node_modules/');
+            pos = __dirname.indexOf(nm);
             if (pos === -1) {
                 _rootDir = path.normalize(__dirname, '..');
             } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ exports.get = function() {
         var cwd = process.cwd();
         var pos = cwd.indexOf(nm);
         if (pos !== -1) {
-            __rootDir =  cwd.substring(0, pos);
+            _rootDir =  cwd.substring(0, pos);
         } else if (fs.existsSync(path.join(cwd, 'package.json'))) {
             _rootDir = cwd;
         } else {


### PR DESCRIPTION
Please consider the proposed change. When the node process gets run from somewhere inside 'node_modules' (and a package.json exists there) then the w-bind attribute of 'marko-widgets' doesn't work. That's because the _rootDir gets wrongly resolved to that inner folder and widget's generated absolute path becomes irrelevant. As an addition the path separator has been normalized in order for it to be platform agnostic: https://nodejs.org/api/path.html#path_path_sep
